### PR TITLE
add Livewire support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "phpunit/phpunit": "^10",
         "illuminate/database": ">= 10",
         "laravel/serializable-closure": "^1.3",
-        "symfony/cache": "^6"
+        "symfony/cache": "^6",
+        "livewire/livewire": ">= 2"
     },
     "extra": {
         "laravel": {

--- a/src/laravel/Vector.php
+++ b/src/laravel/Vector.php
@@ -5,8 +5,9 @@ namespace Pgvector\Laravel;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Wireable;
 
-class Vector extends \Pgvector\Vector implements Castable
+class Vector extends \Pgvector\Vector implements Castable, Wireable
 {
     public static function castUsing(array $arguments): CastsAttributes
     {
@@ -37,8 +38,18 @@ class Vector extends \Pgvector\Vector implements Castable
                     $value = new Vector($value);
                 }
 
-                return (string) $value;
+                return (string)$value;
             }
         };
+    }
+
+    public function toLivewire(): array
+    {
+        return $this->value;
+    }
+
+    public static function fromLivewire($value): Vector
+    {
+        return new Vector($value);
     }
 }


### PR DESCRIPTION
if the package is used with `Livewire` or `FilamentPHP` , it will error : 

`Property type not supported in Livewire for property: [{}]`

so this pull-request is fixing the issue by implementing `Wireable`